### PR TITLE
Fix dependencies

### DIFF
--- a/ObjectLayout-benchmarks/pom.xml
+++ b/ObjectLayout-benchmarks/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.objectlayout</groupId>
-            <artifactId>ObjectLayout-benchmarks</artifactId>
+            <artifactId>ObjectLayout-examples</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>ObjectLayout</module>
+        <module>ObjectLayout-examples</module>
         <module>ObjectLayout-benchmarks</module>
     </modules>
 </project>


### PR DESCRIPTION
Cloning the repo and building with `mvn install` fails because ObjectLayout-benchmarks is depending on itself, so this PR is removing this dependency.
Then the same module does not compile because of missing `SAHashMap`, which is located in `ObjectLayout-examples`. So I added this module to the <modules> of the parent pom and added the dependency to the ObjectLayout-benchmarks pom.
